### PR TITLE
Fix hiera gem to be usable with hiera V5

### DIFF
--- a/lib/puppet/reports/sentry.rb
+++ b/lib/puppet/reports/sentry.rb
@@ -1,5 +1,6 @@
-require 'hiera'
 require 'puppet'
+require 'yaml'
+# require 'pp'
 
 begin
     require 'rubygems'
@@ -14,7 +15,18 @@ rescue LoadError => e
 end
 
 Puppet::Reports.register_report(:sentry) do
+    # Description
     desc = 'Puppet reporter designed to send failed runs to a sentry server'
+
+    # Load the config else error
+    # The file sentry.yaml should be in the root of the environment
+    config_path = File.join([File.dirname(Puppet.settings[:config]), "sentry.yaml"])
+
+    unless File.exist?(config_path)
+        raise(Puppet::ParseError, "Sentry config " + config_path + " doesn't exist")
+    end
+
+    CONFIG = YAML.load_file(config_path)
 
     # Process an event
     def process
@@ -23,50 +35,53 @@ Puppet::Reports.register_report(:sentry) do
             return
         end
 
-        config = hiera.lookup('sentry', {}, self, nil, :priority)
-
         # Check the config contains what we need
-        if not config[:dsn]
+        if not CONFIG[:sentry_dsn]
             raise(Puppet::ParseError, "Sentry did not contain a dsn")
         end
+
+         if self.respond_to?('environment')
+             @environment = self.environment
+         else
+             @environment = 'production'
+         end
 
          if self.respond_to?(:host)
              @host = self.host
          end
 
-         if self.respond_to?(:kind)
-             @kind = self.kind
-         end
-         if self.respond_to?(:puppet_version)
-           @puppet_version = self.puppet_version
-         end
-
-         if self.respond_to?(:status)
-           @status = self.status
-         end
-
-        # Configure raven
-        Raven.configure do |config|
-            config.dsn = config[:dsn]
+     
+        if self.respond_to?(:puppet_version)
+          @puppet_version = self.puppet_version
         end
 
-        # Get the important looking stuff to sentry
-        self.logs.each do |log|
-            if log.level.to_s == 'err'
-                Raven.captureMessage(log.message, {
-                  :server_name => @host,
-                  :tags => {
-                    'status'      => @status,
-                    'version'     => @puppet_version,
-                    'kind'        => @kind,
-                  },
-                  :extra => {
-                    'source' => log.source,
-                    'line'   => log.line,
-                    'file'   => log.file,
-                  },
-                })
-            end
+        if self.respond_to?(:status)
+          @status = self.status
         end
-    end
+
+       # Configure raven
+       Raven.configure do |config|
+           config.dsn = CONFIG[:sentry_dsn]
+           config.current_environment = @environment
+       end
+
+       # Get the important looking stuff to sentry
+       # pp self
+       self.logs.each do |log|
+           if log.level.to_s == 'err'
+                 Raven.captureMessage(log.message, {
+                   :server_name => @host,
+                   :tags => {
+                     'status'      => @status,
+                     'version'     => @puppet_version,                    
+                   },
+                   :extra => {
+                     'source' => log.source,
+                     'line'   => log.line,
+                     'file'   => log.file,
+                   },
+                 })
+           end
+       end
+   end
 end

--- a/lib/puppet/reports/sentry.rb
+++ b/lib/puppet/reports/sentry.rb
@@ -1,4 +1,4 @@
-require 'hiera_puppet'
+require 'hiera'
 require 'puppet'
 
 begin
@@ -23,7 +23,7 @@ Puppet::Reports.register_report(:sentry) do
             return
         end
 
-        config = HieraPuppet.lookup('sentry', {}, self, nil, :priority)
+        config = hiera.lookup('sentry', {}, self, nil, :priority)
 
         # Check the config contains what we need
         if not config[:dsn]


### PR DESCRIPTION
The old sentry-puppet module doesn't work with hiera 5. 